### PR TITLE
Cloudflareでビルド時にエラーが出た件への対応

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -51,6 +51,11 @@ export default defineConfig({
     remarkRehype: {
       footnoteLabel: "脚注"
     },
+  },
+  image: {
+    service: {
+      entrypoint: 'astro/assets/services/noop'
+    }
   }
 });
 


### PR DESCRIPTION
CloudflareではAstro組み込みのSquooshとSharpによる画像最適化をサポートしていないため、``astro:assets``でエラーが発生したようだ。
そのため、公式マニュアルに記載された情報に従ってエラーなしで動作するためのコードを追加した。
その結果ビルド時にエラーが起きなくなった。

マニュアルには「Astroはこれらの環境では画像の変換や処理をおこないません」とあるが、どう違うのか確認し、今後どうするか考えたい（おそらく画像の最適化が行われないとかではないかと思われる）