### PR TITLE
プロファイル表示周辺のレスポンシブ対応関連の修正

### DIFF
--- a/src/components/BlogFooterProfile.astro
+++ b/src/components/BlogFooterProfile.astro
@@ -3,8 +3,8 @@ import {site, infoLinks} from "../consts";
 import {Content as ProfileText} from '@/content/part/blog-footer-profile.md';
 ---
 
-<div class="shadow-lg rounded-lg w-auto flex items-center justify-center bg-skin-card p-2">
-  <div class="flex flex-col items-center justify-center m-2 p-2">
+<div class="shadow-lg rounded-lg w-auto md:flex md:justify-center items-center bg-skin-card p-2">
+  <div class="m-2 p-2">
     <img class="avatar" src={site.avatar} alt="avatar"/>
   </div>
   <div class="flex flex-col justify-center m-2 p-2 gap-2">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -67,8 +67,11 @@ let tagCount = getCountByTagName(blogs);
     }
   </div>
   <div id="personal-info" class="hidden break-all overflow-y-auto pb-8" style="height: calc(100vh - 64px)">
-    <img class="avatar my-4 mx-auto" src={site.avatar} alt="avatar"/>
-    <div class="mb-2 text-center">{site.motto}</div>
+    <img class="avatar mt-4 mx-auto" src={site.avatar} alt="avatar"/>
+    <div class="mb-2 text-center">
+      <h2>{site.author}</h2>
+      <div>{site.motto}</div>
+    </div>
     <div class="flex items-center justify-center flex-wrap">
       {
         infoLinks.map((infoItem) => (

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -320,8 +320,9 @@ menu {
 .avatar {
   border-radius: 50%;
   padding: 4px;
+  aspect-ratio: 1 / 1;
   width: 96px;
-  height: 96px;
+  height: auto;
   object-fit: cover;
   background-color: transparent;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
スマホでヘッダのボタンからサイドバー情報を表示した場合に投稿者名表示、記事下の著者欄のレスポンシブ対応